### PR TITLE
Switch to EXIF UserComment for metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ base64 -w 0 public_key.pem > public_key_base64.txt
 3. **Cryptographic Implementation**:
    - User email encrypted with AES-256-CBC
    - Digital signature created over: `[image_buffer + encrypted_email + timestamp]`
-   - Signature embedded in EXIF data (JPEG) or tEXt chunks (PNG)
+   - Signature embedded in EXIF **UserComment** (JPEG) or tEXt chunks (PNG)
 
 ## 🛡️ Security Features
 

--- a/src/app/api/sign/route.ts
+++ b/src/app/api/sign/route.ts
@@ -244,7 +244,7 @@ async function processImage(
       // 3. Add our metadata (with the placeholder) to the existing EXIF data
       if (!exifDict['0th']) exifDict['0th'] = {};
       if (!exifDict['Exif']) exifDict['Exif'] = {};
-      exifDict['0th'][piexif.ImageIFD.ImageDescription] = placeholderSignatureString;
+      exifDict['Exif'][piexif.ExifIFD.UserComment] = placeholderSignatureString;
       exifDict['0th'][piexif.ImageIFD.Software] = 'Image-Sign Application';
       
       // 4. Create the image body that will actually be signed
@@ -278,8 +278,8 @@ async function processImage(
       // 7. Now, create the final EXIF data with the REAL signature
       signaturePayload.signature = signature;
       const finalSignatureString = JSON.stringify(signaturePayload);
-      if (!exifDict['0th']) exifDict['0th'] = {};
-      exifDict['0th'][piexif.ImageIFD.ImageDescription] = finalSignatureString;
+      if (!exifDict['Exif']) exifDict['Exif'] = {};
+      exifDict['Exif'][piexif.ExifIFD.UserComment] = finalSignatureString;
 
       // 8. Embed the final EXIF block into the original image buffer
       const finalExifBytes = piexif.dump(exifDict);

--- a/src/app/api/verify/route.ts
+++ b/src/app/api/verify/route.ts
@@ -124,12 +124,12 @@ async function extractMetadata(file: File): Promise<string | null> {
         has0th: !!exifDict['0th'],
         hasExif: !!exifDict['Exif'],
         hasGPS: !!exifDict['GPS'],
-        imageDescriptionExists: !!(exifDict['0th'] && exifDict['0th'][piexif.ImageIFD.ImageDescription])
+        userCommentExists: !!(exifDict['Exif'] && exifDict['Exif'][piexif.ExifIFD.UserComment])
       });
-      
-      // Extract signature from EXIF ImageDescription
-      if (exifDict['0th'] && exifDict['0th'][piexif.ImageIFD.ImageDescription]) {
-        const imageDescription = exifDict['0th'][piexif.ImageIFD.ImageDescription];
+
+      // Extract signature from EXIF UserComment
+      if (exifDict['Exif'] && exifDict['Exif'][piexif.ExifIFD.UserComment]) {
+        const imageDescription = exifDict['Exif'][piexif.ExifIFD.UserComment];
         
         // Check if this is our signature format (JSON payload)
         if (typeof imageDescription === 'string') {
@@ -377,8 +377,8 @@ async function verifyImage(file: File): Promise<VerificationResult> {
 
         // Re-create the placeholder that was used during signing
         const placeholderPayload = { signature: '', email: encryptedEmail, timestamp };
-        if (!exifDict['0th']) exifDict['0th'] = {};
-        exifDict['0th'][piexif.ImageIFD.ImageDescription] = JSON.stringify(placeholderPayload);
+        if (!exifDict['Exif']) exifDict['Exif'] = {};
+        exifDict['Exif'][piexif.ExifIFD.UserComment] = JSON.stringify(placeholderPayload);
 
         // Re-build the image with the placeholder EXIF. This buffer should
         // now be identical to the one that was originally signed.


### PR DESCRIPTION
## Summary
- embed signature data in the JPEG EXIF **UserComment** field instead of ImageDescription
- read UserComment when verifying and reconstructing signatures
- document the new field in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848687d763c8326a70a3d5ffc1c274e